### PR TITLE
feat: UI/UX 개편 시안 (정적 HTML 목업 12페이지 + 공용 CSS)

### DIFF
--- a/public/mockup-shared.css
+++ b/public/mockup-shared.css
@@ -1,0 +1,251 @@
+/* Yeobaek UI 시안 — 공통 (세부 페이지) */
+:root {
+  --emerald-950: #022c22;
+  --emerald-900: #064e3b;
+  --emerald-800: #065f46;
+  --emerald-700: #047857;
+  --emerald-600: #059669;
+  --emerald-100: #d1fae5;
+  --emerald-50: #ecfdf5;
+  --slate-900: #0f172a;
+  --slate-800: #1e293b;
+  --slate-700: #334155;
+  --slate-600: #475569;
+  --slate-500: #64748b;
+  --slate-200: #e2e8f0;
+  --slate-100: #f1f5f9;
+  --rose-50: #fff1f2;
+  --white: #fff;
+  --radius: 1rem;
+  --radius-sm: 0.5rem;
+  --shadow: 0 8px 30px rgba(15, 23, 42, 0.08);
+  --max: 72rem;
+  --font: "Noto Sans KR", "Apple SD Gothic Neo", system-ui, sans-serif;
+  --step--1: clamp(0.8rem, 0.75rem + 0.2vw, 0.9rem);
+  --step-0: clamp(0.95rem, 0.88rem + 0.3vw, 1.05rem);
+  --step-1: clamp(1.05rem, 0.95rem + 0.45vw, 1.2rem);
+  --step-2: clamp(1.35rem, 1.1rem + 0.9vw, 1.75rem);
+  --step-3: clamp(1.75rem, 1.35rem + 1.4vw, 2.25rem);
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html { scroll-behavior: smooth; }
+body {
+  margin: 0;
+  font-family: var(--font);
+  font-size: var(--step-0);
+  color: var(--slate-900);
+  background: #f8fafc;
+  line-height: 1.6;
+}
+
+.skip {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip:focus {
+  left: 1rem;
+  top: 1rem;
+  width: auto;
+  height: auto;
+  padding: 0.5rem 1rem;
+  background: var(--emerald-900);
+  color: var(--white);
+  border-radius: var(--radius-sm);
+  z-index: 9999;
+}
+
+/* ----- Subpage header (통일) ----- */
+.mock-nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(6, 78, 59, 0.92);
+  backdrop-filter: blur(12px);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+}
+.mock-nav__inner {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: 0.65rem 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+.mock-nav__brand {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-decoration: none;
+  color: var(--white);
+  font-weight: 700;
+  font-size: var(--step-1);
+}
+.mock-nav__brand img { height: 1.75rem; width: auto; }
+.mock-nav__links {
+  flex: 1;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 0.5rem 1rem;
+}
+.mock-nav__links a {
+  color: rgba(255, 255, 255, 0.9);
+  text-decoration: none;
+  font-size: var(--step--1);
+  font-weight: 500;
+  padding: 0.3rem 0.4rem;
+  border-radius: 0.35rem;
+}
+.mock-nav__links a:hover,
+.mock-nav__links a:focus-visible {
+  background: rgba(255, 255, 255, 0.12);
+  outline: none;
+}
+.mock-nav__back {
+  color: rgba(255, 255, 255, 0.95);
+  text-decoration: none;
+  font-size: var(--step--1);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.mock-nav__back:hover { text-decoration: underline; }
+
+@media (max-width: 640px) {
+  .mock-nav__links { order: 3; width: 100%; justify-content: flex-start; padding-top: 0.35rem; border-top: 1px solid rgba(255,255,255,0.12); }
+}
+
+/* ----- Layout ----- */
+.mock-wrap {
+  max-width: var(--max);
+  margin: 0 auto;
+  padding: clamp(1.5rem, 4vw, 2.5rem) 1.25rem;
+}
+.mock-page-title {
+  font-size: var(--step-3);
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  margin: 0 0 0.5rem;
+  color: var(--slate-900);
+}
+.mock-page-lead {
+  color: var(--slate-600);
+  font-size: var(--step-1);
+  max-width: 40rem;
+  margin: 0 0 2rem;
+  line-height: 1.65;
+}
+
+/* ----- Cards & panels ----- */
+.mock-card {
+  background: var(--white);
+  border-radius: var(--radius);
+  border: 1px solid var(--slate-200);
+  box-shadow: var(--shadow);
+  padding: 1.25rem 1.5rem;
+}
+.mock-card--muted { background: var(--slate-100); border-color: transparent; }
+
+.mock-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.55rem 1.1rem;
+  border-radius: 999px;
+  font-family: inherit;
+  font-size: var(--step--1);
+  font-weight: 600;
+  border: none;
+  cursor: pointer;
+  text-decoration: none;
+  transition: transform 0.12s, box-shadow 0.12s;
+}
+.mock-btn:focus-visible {
+  outline: 2px solid var(--emerald-600);
+  outline-offset: 2px;
+}
+.mock-btn--primary {
+  background: var(--emerald-700);
+  color: var(--white);
+}
+.mock-btn--primary:hover { background: var(--emerald-800); }
+.mock-btn--ghost {
+  background: var(--white);
+  color: var(--emerald-800);
+  border: 1px solid var(--slate-200);
+}
+.mock-btn--ghost:hover { border-color: var(--emerald-600); background: var(--emerald-50); }
+.mock-btn--dark {
+  background: var(--slate-900);
+  color: var(--white);
+}
+.mock-btn--dark:hover { background: var(--slate-800); }
+
+.mock-input {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border: 1px solid var(--slate-200);
+  border-radius: var(--radius-sm);
+  font-family: inherit;
+  font-size: var(--step-0);
+}
+.mock-input:focus {
+  outline: 2px solid var(--emerald-600);
+  outline-offset: 0;
+  border-color: var(--emerald-600);
+}
+
+.mock-label {
+  display: block;
+  font-size: var(--step--1);
+  font-weight: 600;
+  color: var(--slate-700);
+  margin-bottom: 0.35rem;
+}
+
+.mock-footer {
+  margin-top: 3rem;
+  padding: 1.5rem 1.25rem;
+  text-align: center;
+  font-size: 0.8rem;
+  color: var(--slate-500);
+  background: var(--slate-100);
+  border-top: 1px solid var(--slate-200);
+}
+.mock-footer a { color: var(--emerald-700); }
+
+.mock-badge {
+  display: inline-block;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--emerald-800);
+  background: var(--emerald-100);
+  padding: 0.2rem 0.45rem;
+  border-radius: 0.25rem;
+  margin-bottom: 0.5rem;
+}
+
+/* Grid helpers */
+.mock-grid-2 {
+  display: grid;
+  gap: 1.25rem;
+}
+@media (min-width: 768px) {
+  .mock-grid-2 { grid-template-columns: 1fr 1fr; }
+}
+.mock-grid-3 {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 640px) {
+  .mock-grid-3 { grid-template-columns: repeat(3, 1fr); }
+}

--- a/public/mockup-shell-v3.css
+++ b/public/mockup-shell-v3.css
@@ -1,0 +1,546 @@
+/* Yeobaek UI 시안 v3 공통 셸 — 메인·세부 HTML 공용 */
+
+:root {
+  --v3-header-h: 3.25rem;
+}
+
+body.v3-shell {
+  margin: 0;
+  background: #fafafa;
+}
+
+/* ----- Header (Recruit형) ----- */
+.v3-head {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  border-bottom: 1px solid rgba(226, 232, 240, 0.85);
+  background: rgba(255, 255, 255, 0.92);
+  backdrop-filter: blur(10px);
+}
+.v3-head-inner {
+  max-width: 64rem;
+  margin: 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.65rem 1.25rem;
+  min-height: var(--v3-header-h);
+}
+.v3-brand {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+  text-decoration: none;
+  color: #0f172a;
+}
+.v3-brand img {
+  height: 1.75rem;
+  width: auto;
+}
+.v3-brand-title {
+  font-size: 1.125rem;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  line-height: 1.2;
+}
+.v3-brand-pipe {
+  margin-left: 0.35rem;
+  font-size: 0.875rem;
+  font-weight: 400;
+  color: #94a3b8;
+}
+.v3-head-nav {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem 0.35rem;
+}
+.v3-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.35rem 0.65rem;
+  border-radius: 0.375rem;
+  font-size: 0.875rem;
+  font-weight: 500;
+  text-decoration: none;
+  color: #64748b;
+  transition: background 0.15s, color 0.15s;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+}
+.v3-pill:hover {
+  background: #f1f5f9;
+  color: #0f172a;
+}
+.v3-pill--active {
+  background: #ecfdf5;
+  color: #064e3b;
+}
+.v3-pill--ghost {
+  color: #94a3b8;
+  margin-right: 0.25rem;
+}
+.v3-pill--ghost:hover {
+  color: #334155;
+  background: transparent;
+}
+@media (max-width: 640px) {
+  .v3-head-nav .v3-pill--ghost {
+    display: none;
+  }
+}
+
+/* Floating 문의 */
+.v3-float {
+  position: fixed;
+  right: 0;
+  top: 50%;
+  transform: translateY(-50%);
+  z-index: 90;
+  writing-mode: vertical-rl;
+  text-orientation: mixed;
+  background: linear-gradient(180deg, #14b8a6, #047857);
+  color: #fff;
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  padding: 1rem 0.45rem;
+  border-radius: 0.5rem 0 0 0.5rem;
+  box-shadow: -4px 4px 20px rgba(0, 0, 0, 0.12);
+  text-decoration: none;
+}
+@media (max-width: 480px) {
+  .v3-float {
+    display: none;
+  }
+}
+
+/* ----- 메인 전용: 전면 히어로 ----- */
+.v3-hero {
+  position: relative;
+  min-height: calc(100svh - var(--v3-header-h));
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 2rem 1.25rem 4rem;
+  overflow: hidden;
+}
+.v3-hero-bg {
+  position: absolute;
+  inset: 0;
+  background: #065f46 center / cover no-repeat;
+  background-image: linear-gradient(135deg, rgba(6, 78, 59, 0.45), rgba(15, 23, 42, 0.35)),
+    url("/backend/image/gomdol.jpg");
+  filter: brightness(0.92);
+}
+.v3-hero-overlay {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
+}
+.v3-hero-content {
+  position: relative;
+  z-index: 2;
+  max-width: 48rem;
+}
+.v3-hero-kicker {
+  display: inline-block;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: rgba(255, 255, 255, 0.95);
+  letter-spacing: 0.04em;
+  margin: 0 0 0.75rem;
+  text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+}
+.v3-hero h1 {
+  margin: 0 0 1rem;
+  font-size: clamp(2.25rem, 6vw, 3.75rem);
+  font-weight: 800;
+  color: #fff;
+  line-height: 1.15;
+  letter-spacing: -0.03em;
+  text-shadow: 0 2px 24px rgba(0, 0, 0, 0.35);
+}
+.v3-hero-lead {
+  margin: 0 auto 1.5rem;
+  font-size: clamp(1rem, 2vw, 1.15rem);
+  color: rgba(255, 255, 255, 0.9);
+  max-width: 34rem;
+  line-height: 1.65;
+  text-shadow: 0 1px 8px rgba(0, 0, 0, 0.3);
+}
+.v3-hero-cta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+  margin-top: 0.5rem;
+}
+.v3-hero .btn-a {
+  min-width: 11rem;
+  padding: 0.85rem 1.25rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-family: inherit;
+  cursor: pointer;
+  border: none;
+  transition: transform 0.15s;
+}
+.v3-hero .btn-a:hover {
+  transform: scale(1.03);
+}
+.v3-hero .btn-solid {
+  background: rgba(243, 244, 246, 0.95);
+  color: #0f172a;
+}
+.v3-hero .btn-outline {
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+}
+.v3-scroll {
+  position: absolute;
+  bottom: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  color: rgba(255, 255, 255, 0.88);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.12em;
+  z-index: 2;
+}
+
+/* ----- 세부 페이지: 타이틀 띠 ----- */
+.v3-pagehead {
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  padding: clamp(1.35rem, 3vw, 2rem) 1.25rem;
+}
+.v3-pagehead-inner {
+  max-width: 64rem;
+  margin: 0 auto;
+}
+.v3-pagehead .v3-h1 {
+  margin: 0;
+  font-size: clamp(1.5rem, 3.5vw, 2rem);
+  font-weight: 800;
+  letter-spacing: -0.03em;
+  color: #0f172a;
+}
+.v3-pagehead .v3-page-lead {
+  margin: 0.5rem 0 0;
+  color: #64748b;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  max-width: 40rem;
+}
+
+/* ----- 본문 공통 ----- */
+.v3-section {
+  max-width: 72rem;
+  margin: 0 auto;
+  padding: clamp(2.5rem, 5vw, 4rem) 1.25rem;
+}
+.v3-eyebrow {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #047857;
+  margin: 0 0 0.75rem;
+}
+.v3-h2 {
+  font-size: clamp(1.75rem, 4vw, 2.35rem);
+  font-weight: 800;
+  margin: 0 0 0.5rem;
+  letter-spacing: -0.03em;
+  color: #0f172a;
+}
+.v3-lead {
+  color: #475569;
+  font-size: clamp(1rem, 2vw, 1.1rem);
+  line-height: 1.65;
+  margin: 0;
+  max-width: 36rem;
+}
+.v3-band-white {
+  background: #fff;
+  border-top: 1px solid #e2e8f0;
+}
+.v3-band-slate {
+  background: #f8fafc;
+  border-top: 1px solid #e2e8f0;
+}
+
+/* 통계 그리드 */
+.v3-stat-grid {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+.v3-stat-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  padding: 1.5rem 1.25rem;
+  text-align: center;
+  box-shadow: 0 4px 20px rgba(15, 23, 42, 0.04);
+}
+.v3-stat-card .v3-stat-num {
+  margin: 0;
+  font-size: 2.5rem;
+  font-weight: 800;
+  color: #065f46;
+  letter-spacing: -0.03em;
+}
+.v3-stat-card .v3-stat-suffix {
+  font-size: 1rem;
+  font-weight: 600;
+  color: #64748b;
+}
+.v3-stat-card .v3-stat-label {
+  margin: 0.35rem 0 0;
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: #64748b;
+}
+
+/* 서비스 카드 (+ 상단 미디어) */
+.v3-cards {
+  display: grid;
+  gap: 1.25rem;
+  grid-template-columns: 1fr;
+}
+@media (min-width: 720px) {
+  .v3-cards {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+.v3-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 1rem;
+  box-shadow: 0 4px 20px rgba(15, 23, 42, 0.04);
+  display: flex;
+  flex-direction: column;
+  min-height: 17rem;
+  overflow: hidden;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+.v3-card:hover {
+  border-color: #6ee7b7;
+  box-shadow: 0 8px 28px rgba(6, 95, 70, 0.1);
+}
+.v3-card-media {
+  height: 10rem;
+  background: linear-gradient(135deg, #ecfdf5, #d1fae5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  overflow: hidden;
+}
+.v3-card-media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+.v3-card-body {
+  padding: 1.25rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.v3-card-icon {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  margin-bottom: 1rem;
+  background: linear-gradient(135deg, #d1fae5, #ecfdf5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.v3-card-icon img {
+  width: 1.75rem;
+  height: 1.75rem;
+  object-fit: contain;
+}
+.v3-card h3 {
+  margin: 0 0 0.65rem;
+  font-size: 1.1rem;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: #0f172a;
+}
+.v3-card ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  color: #475569;
+  font-size: 0.88rem;
+  line-height: 1.55;
+  flex: 1;
+}
+.v3-card a {
+  margin-top: 1rem;
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: #047857;
+  text-decoration: none;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+}
+
+/* 소식 */
+.v3-news-grid {
+  display: grid;
+  gap: 2rem;
+}
+@media (min-width: 768px) {
+  .v3-news-grid {
+    grid-template-columns: minmax(12rem, 16rem) 1fr;
+    gap: 3rem;
+    align-items: start;
+  }
+}
+.v3-news-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-top: 1px solid #e2e8f0;
+}
+.v3-news-list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 1rem;
+  align-items: baseline;
+  padding: 1.1rem 0;
+  border-bottom: 1px solid #e2e8f0;
+}
+.v3-news-date {
+  font-weight: 800;
+  color: #065f46;
+  font-size: 0.95rem;
+  white-space: nowrap;
+}
+.v3-news-list a {
+  color: #0f172a;
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+.v3-news-list a:hover {
+  color: #047857;
+  text-decoration: underline;
+}
+
+/* 문의 밴드 */
+.v3-inquiry {
+  position: relative;
+  overflow: hidden;
+  background: linear-gradient(115deg, #0d9488 0%, #047857 45%, #065f46 100%);
+  color: #fff;
+  padding: clamp(2.5rem, 6vw, 4rem) 1.25rem;
+}
+.v3-inquiry-grid {
+  max-width: 72rem;
+  margin: 0 auto;
+  position: relative;
+  z-index: 1;
+  display: grid;
+  gap: 2rem;
+}
+@media (min-width: 800px) {
+  .v3-inquiry-grid {
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+    align-items: start;
+  }
+}
+.v3-inquiry h2 {
+  margin: 0 0 0.75rem;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  font-weight: 800;
+  line-height: 1.3;
+}
+.v3-inquiry p {
+  margin: 0;
+  opacity: 0.92;
+  font-size: 0.95rem;
+  line-height: 1.65;
+  max-width: 28rem;
+}
+.v3-form {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+.v3-form label {
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  opacity: 0.9;
+}
+.v3-form input,
+.v3-form textarea {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  background: rgba(255, 255, 255, 0.1);
+  color: #fff;
+  font-family: inherit;
+  font-size: 0.9rem;
+}
+.v3-form input::placeholder,
+.v3-form textarea::placeholder {
+  color: rgba(255, 255, 255, 0.55);
+}
+.v3-form textarea {
+  min-height: 5.5rem;
+  resize: vertical;
+}
+.v3-form button {
+  align-self: flex-start;
+  margin-top: 0.35rem;
+  padding: 0.65rem 1.35rem;
+  border-radius: 999px;
+  border: none;
+  cursor: pointer;
+  background: #fff;
+  color: #064e3b;
+  font-weight: 800;
+  font-size: 0.9rem;
+  font-family: inherit;
+}
+
+/* 인증 페이지용 래퍼 */
+.v3-auth-shell {
+  min-height: calc(100svh - var(--v3-header-h) - 5rem);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2rem 1.25rem 3rem;
+  background: linear-gradient(180deg, #ecfdf5, #f8fafc);
+}
+.v3-auth-card {
+  width: 100%;
+  max-width: 26rem;
+  background: #fff;
+  border-radius: 1rem;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 8px 30px rgba(15, 23, 42, 0.08);
+  padding: 1.75rem 1.5rem;
+}

--- a/public/ui-mockup-about.html
+++ b/public/ui-mockup-about.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>소개 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .timeline { position: relative; max-width: 48rem; margin: 0 auto; padding: 0 0 2rem; }
+    .timeline::before {
+      content: ""; position: absolute; left: 50%; top: 0; bottom: 0; width: 2px;
+      background: linear-gradient(#059669, #d1fae5); transform: translateX(-50%); display: none;
+    }
+    @media (min-width: 768px) { .timeline::before { display: block; } }
+    .tl-row { display: grid; gap: 1rem; margin-bottom: 2rem; }
+    @media (min-width: 768px) { .tl-row { grid-template-columns: 1fr 1fr; align-items: center; } }
+    .tl-card { background: #fff; border: 1px solid #e2e8f0; border-radius: 1rem; padding: 1.25rem; box-shadow: 0 4px 20px rgba(15,23,42,0.06); }
+    .tl-year { font-size: 1.35rem; font-weight: 800; color: #065f46; margin: 0 0 0.35rem; }
+    .team-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+    @media (min-width: 640px) { .team-grid { grid-template-columns: repeat(3, 1fr); } }
+    .team-card { text-align: center; padding: 1.25rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 1rem; }
+    .team-card img { width: 5.5rem; height: 5.5rem; border-radius: 999px; object-fit: cover; margin-bottom: 0.75rem; border: 3px solid #d1fae5; }
+    .team-card h3 { margin: 0; font-size: 1.05rem; }
+    .team-card p { margin: 0.35rem 0 0; font-size: 0.85rem; color: #64748b; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| About</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-pagehead">
+    <div class="v3-pagehead-inner">
+      <p class="v3-eyebrow" style="margin-bottom:0.35rem">About</p>
+      <h1 class="v3-h1">동아리 여백을 소개합니다</h1>
+      <p class="v3-page-lead">문헌정보학을 기반으로 학과의 소통과 정보 공유를 위해 만들어진 동아리입니다.</p>
+    </div>
+  </div>
+
+  <main id="main" class="v3-section v3-band-slate" style="padding-top:2rem">
+    <h2 class="v3-h2" style="text-align:center">연혁</h2>
+    <p class="v3-lead" style="margin:0 auto 2rem;text-align:center">중요한 해를 카드로 나누어 스캔하기 쉽게.</p>
+    <div class="timeline">
+      <div class="tl-row">
+        <div class="tl-card">
+          <p class="tl-year">2022</p>
+          <p style="margin:0;color:#475569">여백 창립, 학과 내 정보 공유 취지로 출발.</p>
+        </div>
+        <div></div>
+      </div>
+      <div class="tl-row">
+        <div></div>
+        <div class="tl-card">
+          <p class="tl-year">2025</p>
+          <p style="margin:0;color:#475569">웹·챗봇·아카이빙 등 디지털 서비스 확장.</p>
+        </div>
+      </div>
+    </div>
+
+    <h2 class="v3-h2" style="text-align:center;margin-top:2.5rem">운영진</h2>
+    <p class="v3-lead" style="margin:0 auto 2rem;text-align:center">역할 태그로 구분.</p>
+    <div class="team-grid">
+      <div class="team-card">
+        <img src="/backend/image/yuja.png" alt="" />
+        <h3>방규리</h3>
+        <p>운영 · 기획 · 프론트</p>
+      </div>
+      <div class="team-card">
+        <img src="/backend/image/mj_logo.png" alt="" />
+        <h3>김명주</h3>
+        <p>운영 지원 · 기획</p>
+      </div>
+      <div class="team-card">
+        <img src="/backend/image/duzzonku.png" alt="" />
+        <h3>Coming Soon</h3>
+        <p>신입 부원</p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/ui-mockup-main-v3.html">메인 v3</a> · <a href="/about">실제 About</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-archiving.html
+++ b/public/ui-mockup-archiving.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>디지털 아카이빙 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .steps { display: flex; flex-wrap: wrap; gap: 0.75rem; margin: 1.5rem 0 2rem; }
+    .step { flex: 1; min-width: 8rem; background: #ecfdf5; border: 1px solid #d1fae5; border-radius: 0.5rem; padding: 0.75rem; font-size: 0.85rem; font-weight: 600; color: #064e3b; text-align: center; }
+    .wait-box { text-align: center; padding: 2rem 1rem; background: #fff; border: 1px solid #e2e8f0; border-radius: 1rem; }
+    .wait-box img { max-width: 22rem; width: 100%; height: auto; margin: 1.5rem auto 0; display: block; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Archiving</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-pagehead">
+    <div class="v3-pagehead-inner">
+      <p class="v3-eyebrow" style="margin-bottom:0.35rem">Archiving</p>
+      <h1 class="v3-h1">디지털 아카이빙</h1>
+      <p class="v3-page-lead">준비 중일 때도 로드맵과 문의 경로를 보여 주는 레이아웃입니다.</p>
+    </div>
+  </div>
+
+  <main id="main" class="v3-section v3-band-slate">
+    <div class="steps" role="list">
+      <div class="step" role="listitem">1. 수집</div>
+      <div class="step" role="listitem">2. 메타데이터</div>
+      <div class="step" role="listitem">3. 검색</div>
+      <div class="step" role="listitem">4. 공유</div>
+    </div>
+    <div class="wait-box">
+      <p style="margin:0 0 1rem;color:#475569;font-size:1rem">현재 페이지는 Coming Soon 중심입니다.</p>
+      <a class="mock-btn mock-btn--primary" href="mailto:lisyeobaek@gmail.com">문의 메일</a>
+      <img src="/backend/image/wait.png" alt="" />
+    </div>
+  </main>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/ui-mockup-main-v3.html">메인 v3</a> · <a href="/archiving">실제 아카이빙</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-chatbot.html
+++ b/public/ui-mockup-chatbot.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>챗봇 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .split { display: grid; gap: 2rem; align-items: start; max-width: 56rem; margin: 0 auto; }
+    @media (min-width: 900px) { .split { grid-template-columns: 220px 1fr; } }
+    .mascot-wrap { text-align: center; }
+    .bubble { display: inline-block; background: #fff; border: 1px solid #e2e8f0; border-radius: 1rem; padding: 0.65rem 1rem; font-size: 0.85rem; font-weight: 600; margin-bottom: 0.75rem; box-shadow: 0 4px 20px rgba(15,23,42,0.06); }
+    .mascot-oval { background: #ecfdf5; border-radius: 999px; width: 13rem; height: 13rem; margin: 0 auto; display: flex; align-items: center; justify-content: center; }
+    .mascot-oval img { width: 10rem; height: 10rem; object-fit: contain; }
+    .chat-shell { border: 1px solid #e2e8f0; border-radius: 1rem; overflow: hidden; box-shadow: 0 8px 30px rgba(15,23,42,0.08); max-width: 26rem; margin: 0 auto; }
+    .chat-head { background: #047857; color: #fff; padding: 0.75rem 1rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.9rem; }
+    .chat-body { background: #fff1f2; padding: 1rem; min-height: 14rem; display: flex; flex-direction: column; gap: 0.65rem; }
+    .msg { display: flex; gap: 0.35rem; align-items: flex-end; }
+    .msg--user { justify-content: flex-end; }
+    .msg-bubble { max-width: 82%; padding: 0.55rem 0.85rem; border-radius: 1rem; font-size: 0.9rem; line-height: 1.5; }
+    .msg--bot .msg-bubble { background: #fff; border: 1px solid #e2e8f0; border-bottom-left-radius: 0.25rem; }
+    .msg--user .msg-bubble { background: #047857; color: #fff; border-bottom-right-radius: 0.25rem; }
+    .quick-row { display: flex; flex-wrap: wrap; gap: 0.4rem; padding: 0.5rem 0.75rem; background: #f8fafc; border-top: 1px solid #e2e8f0; }
+    .quick-row button { font-size: 0.72rem; padding: 0.35rem 0.65rem; border-radius: 999px; border: 1px solid #e2e8f0; background: #fff; cursor: pointer; font-family: inherit; }
+    .chat-input-row { display: flex; gap: 0.5rem; padding: 0.65rem 0.75rem; background: #f8fafc; border-top: 1px solid #e2e8f0; }
+    .chat-input-row input { flex: 1; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Chatbot</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-pagehead">
+    <div class="v3-pagehead-inner">
+      <p class="v3-eyebrow" style="margin-bottom:0.35rem">Chatbot</p>
+      <h1 class="v3-h1">여불이와 대화하기</h1>
+      <p class="v3-page-lead">마스코트 영역과 채팅 UI를 나란히 둔 레이아웃입니다.</p>
+    </div>
+  </div>
+
+  <main id="main" class="v3-section v3-band-white">
+    <div class="split">
+      <div class="mascot-wrap">
+        <div class="bubble">무엇이든 물어보살</div>
+        <div class="mascot-oval">
+          <img src="/backend/image/mascot_chatbot.png" alt="여백 챗봇 마스코트" />
+        </div>
+      </div>
+      <div>
+        <div class="chat-shell">
+          <div class="chat-head">
+            <span>Yeobaek Chat-bot</span>
+            <span style="opacity:0.85;font-size:0.72rem">온라인</span>
+          </div>
+          <div class="chat-body" aria-live="polite">
+            <div class="msg">
+              <div class="msg-bubble">안녕하세요! 저는 여백의 AI 백봇이에요.</div>
+            </div>
+            <div class="msg msg--user">
+              <div class="msg-bubble">추천 시스템 구조가 궁금해요</div>
+            </div>
+            <div class="msg">
+              <div class="msg-bubble">(시안) 실제 답변은 API 연동 후 표시됩니다.</div>
+            </div>
+          </div>
+          <div class="quick-row">
+            <button type="button">여백 × LIS</button>
+            <button type="button">추천 시스템</button>
+            <button type="button">시소러스 vs 온톨로지</button>
+          </div>
+          <div class="chat-input-row">
+            <input class="mock-input" type="text" placeholder="메시지를 입력하세요" aria-label="메시지" />
+            <button type="button" class="mock-btn mock-btn--primary" style="flex-shrink:0">전송</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/ui-mockup-main-v3.html">메인 v3</a> · <a href="/chatbot">실제 챗봇</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-exhibition.html
+++ b/public/ui-mockup-exhibition.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>산출물 전시 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .cover { background: linear-gradient(145deg, #064e3b, #0f3d2e); color: #fff; border-radius: 1rem; padding: 2rem; text-align: center; margin-bottom: 1.5rem; box-shadow: 0 8px 30px rgba(6,78,59,0.2); }
+    .cover img { height: 3rem; margin-bottom: 1rem; }
+    .lab-grid { display: grid; gap: 1rem; grid-template-columns: 1fr; }
+    @media (min-width: 560px) { .lab-grid { grid-template-columns: repeat(2, 1fr); } }
+    @media (min-width: 900px) { .lab-grid { grid-template-columns: repeat(3, 1fr); } }
+    .lab-tile { background: #fff; border: 1px solid #e2e8f0; border-radius: 1rem; padding: 1.15rem; box-shadow: 0 4px 20px rgba(15,23,42,0.04); transition: border-color 0.15s; }
+    .lab-tile:hover { border-color: #059669; }
+    .lab-tile .tag { font-size: 0.65rem; font-weight: 800; letter-spacing: 0.08em; color: #047857; text-transform: uppercase; margin-bottom: 0.35rem; }
+    .lab-tile h3 { margin: 0 0 0.5rem; font-size: 1.05rem; }
+    .lab-tile p { margin: 0; font-size: 0.85rem; color: #64748b; line-height: 1.5; }
+    .kw { display: flex; flex-wrap: wrap; gap: 0.35rem; margin-top: 0.75rem; }
+    .kw span { font-size: 0.65rem; padding: 0.2rem 0.45rem; background: #f1f5f9; border-radius: 999px; color: #475569; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Exhibition</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-pagehead">
+    <div class="v3-pagehead-inner">
+      <p class="v3-eyebrow" style="margin-bottom:0.35rem">Exhibition</p>
+      <h1 class="v3-h1">동아리 산출물 전시</h1>
+      <p class="v3-page-lead">표지 + LAB 그리드 카드 레이아웃입니다.</p>
+    </div>
+  </div>
+
+  <main id="main" class="v3-section v3-band-white">
+    <div class="cover">
+      <img src="/backend/image/logo.png" alt="" />
+      <h2 style="margin:0;font-size:1.65rem">Yeobaek Digital Archive</h2>
+      <p style="margin:0.5rem 0 0;opacity:0.85;font-size:0.9rem">LAB 카탈로그</p>
+    </div>
+    <div class="lab-grid">
+      <article class="lab-tile">
+        <p class="tag">LAB 1</p>
+        <h3>AI 어시스턴트 &amp; 챗봇</h3>
+        <p>자료 검색·응답 자동화.</p>
+        <div class="kw"><span>NLP</span><span>RAG</span></div>
+      </article>
+      <article class="lab-tile">
+        <p class="tag">LAB 2</p>
+        <h3>디지털 아카이빙</h3>
+        <p>문서·회의록 체계적 저장.</p>
+        <div class="kw"><span>Metadata</span></div>
+      </article>
+      <article class="lab-tile">
+        <p class="tag">LAB 3</p>
+        <h3>큐레이션 &amp; 추천</h3>
+        <p>맞춤형 도서·산출물 큐레이션.</p>
+        <div class="kw"><span>Recommendation</span></div>
+      </article>
+      <article class="lab-tile">
+        <p class="tag">LAB 4</p>
+        <h3>인프라 &amp; DevOps</h3>
+        <p>Git, CI/CD, 배포 실습.</p>
+        <div class="kw"><span>Git</span><span>CI/CD</span></div>
+      </article>
+      <article class="lab-tile">
+        <p class="tag">LAB 5</p>
+        <h3>프로젝트 고도화</h3>
+        <p>성능·UX 개선.</p>
+        <div class="kw"><span>Performance</span></div>
+      </article>
+      <article class="lab-tile">
+        <p class="tag">LAB 6</p>
+        <h3>아이디어 랩</h3>
+        <p>브레인스토밍부터 실현까지.</p>
+        <div class="kw"><span>Ideation</span></div>
+      </article>
+    </div>
+  </main>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/ui-mockup-main-v3.html">메인 v3</a> · <a href="/exhibition">실제 전시</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-index.html
+++ b/public/ui-mockup-index.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Yeobaek — UI 시안 목록</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .hub { max-width: 42rem; margin: 0 auto; padding: 2rem 1.25rem 4rem; }
+    .hub h1 { font-size: clamp(1.75rem, 4vw, 2.25rem); margin: 0 0 0.5rem; letter-spacing: -0.03em; }
+    .hub p { color: #475569; margin: 0 0 2rem; line-height: 1.65; }
+    .hub-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 0.65rem; }
+    .hub-list a {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: 1rem 1.15rem; background: #fff; border: 1px solid #e2e8f0;
+      border-radius: 1rem; text-decoration: none; color: #0f172a;
+      font-weight: 600; box-shadow: 0 4px 20px rgba(15, 23, 42, 0.04); transition: border-color 0.15s, transform 0.15s;
+    }
+    .hub-list a:hover { border-color: #059669; transform: translateY(-1px); }
+    .hub-list span { font-size: 0.8rem; font-weight: 500; color: #94a3b8; }
+    .hub-section { margin-top: 2rem; font-size: 0.85rem; color: #64748b; line-height: 1.6; }
+    .hub-section code { font-size: 0.78rem; background: #f1f5f9; padding: 0.1rem 0.35rem; border-radius: 0.25rem; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/ui-mockup-index.html">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Mockups</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="시안 내비">
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-index.html#main">시안 목록</a>
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">메인 v3</a>
+        <a class="v3-pill" href="/">앱 홈</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-pagehead">
+    <div class="v3-pagehead-inner">
+      <p class="v3-eyebrow" style="margin-bottom: 0.35rem">Index</p>
+      <h1 class="v3-h1">정적 HTML 시안</h1>
+      <p class="v3-page-lead">아래 링크는 모두 v3와 동일한 상단 헤더(Recruit형) 맥락을 공유합니다.</p>
+    </div>
+  </div>
+
+  <main id="main" class="hub">
+    <p><code>npm run dev</code> 후 열어 주세요. 리크루트·운영 <code>/admin</code> 제외.</p>
+    <ul class="hub-list">
+      <li><a href="/ui-mockup-main-v3.html">메인 v3 (권장) <span>ui-mockup-main-v3.html</span></a></li>
+      <li><a href="/ui-mockup-yeobaek.html">메인 v1 (히어로 전면·캐러셀) <span>ui-mockup-yeobaek.html</span></a></li>
+      <li><a href="/ui-mockup-main-v2-layout.html">메인 v2 (SINSIWAY형) <span>ui-mockup-main-v2-layout.html</span></a></li>
+      <li><a href="/ui-mockup-about.html">소개 About <span>ui-mockup-about.html</span></a></li>
+      <li><a href="/ui-mockup-chatbot.html">챗봇 상세 <span>ui-mockup-chatbot.html</span></a></li>
+      <li><a href="/ui-mockup-archiving.html">디지털 아카이빙 <span>ui-mockup-archiving.html</span></a></li>
+      <li><a href="/ui-mockup-exhibition.html">산출물 전시 <span>ui-mockup-exhibition.html</span></a></li>
+      <li><a href="/ui-mockup-lab.html">LAB 상세 <span>ui-mockup-lab.html</span></a></li>
+      <li><a href="/ui-mockup-login.html">로그인 <span>ui-mockup-login.html</span></a></li>
+      <li><a href="/ui-mockup-signup.html">회원가입 <span>ui-mockup-signup.html</span></a></li>
+      <li><a href="/ui-mockup-me.html">내 계정 <span>ui-mockup-me.html</span></a></li>
+    </ul>
+    <p class="hub-section">
+      공통: <code>/mockup-shared.css</code> · v3 셸: <code>/mockup-shell-v3.css</code>
+    </p>
+  </main>
+
+  <footer class="mock-footer">
+    시안 허브 · <a href="/ui-mockup-main-v3.html">메인 v3</a> · <a href="/">실제 앱</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-lab.html
+++ b/public/ui-mockup-lab.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>LAB — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .lab-layout { display: grid; gap: 1.5rem; }
+    @media (min-width: 900px) { .lab-layout { grid-template-columns: 14rem 1fr; } }
+    .lab-side { background: #fff; border: 1px solid #e2e8f0; border-radius: 1rem; padding: 1rem; height: fit-content; position: sticky; top: 4.5rem; }
+    .lab-side h2 { margin: 0 0 0.75rem; font-size: 0.75rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.06em; }
+    .lab-side a { display: block; padding: 0.45rem 0.5rem; border-radius: 0.375rem; color: #1e293b; text-decoration: none; font-weight: 500; font-size: 0.9rem; }
+    .lab-side a:hover, .lab-side a[aria-current="page"] { background: #ecfdf5; color: #064e3b; }
+    .meta-grid { display: grid; gap: 0.65rem; grid-template-columns: 1fr; }
+    @media (min-width: 520px) { .meta-grid { grid-template-columns: repeat(2, 1fr); } }
+    .meta-item dt { margin: 0; font-weight: 700; color: #475569; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.04em; }
+    .meta-item dd { margin: 0.2rem 0 0; color: #64748b; font-size: 0.9rem; }
+    .feat-list { margin: 0; padding-left: 1.1rem; color: #475569; }
+    .feat-list li { margin-bottom: 0.35rem; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Lab</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-pagehead">
+    <div class="v3-pagehead-inner">
+      <p class="v3-eyebrow" style="margin-bottom:0.35rem">LAB</p>
+      <h1 class="v3-h1">LAB 상세</h1>
+      <p class="v3-page-lead">좌측 목록 + 우측 상세 메타·설명 패턴입니다.</p>
+    </div>
+  </div>
+
+  <main id="main" class="v3-section v3-band-slate">
+    <div class="lab-layout">
+      <aside class="lab-side" aria-label="LAB 목록">
+        <h2>탐색</h2>
+        <a href="#">LAB 1</a>
+        <a href="#" aria-current="page">LAB 2</a>
+        <a href="#">LAB 3</a>
+        <a href="#">LAB 4</a>
+        <a href="#">LAB 5</a>
+        <a href="#">LAB 6</a>
+      </aside>
+      <article class="mock-card" style="background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1.5rem;box-shadow:0 4px 20px rgba(15,23,42,0.06)">
+        <h2 style="margin:0 0 0.35rem;font-size:1.5rem">LAB 2 — 디지털 아카이빙</h2>
+        <p style="margin:0 0 1.25rem;color:#64748b;font-size:1rem">yeobaek 및 전공 동아리들의 활동 산출물과 문서를 체계적으로 아카이빙합니다.</p>
+        <dl class="meta-grid">
+          <div class="meta-item"><dt>이름</dt><dd>yeobaek 디지털 아카이빙 시스템</dd></div>
+          <div class="meta-item"><dt>기간</dt><dd>2025/03/01 ~ 진행중</dd></div>
+          <div class="meta-item"><dt>주체</dt><dd>문헌정보학과 동아리 여백</dd></div>
+          <div class="meta-item"><dt>기술 스택</dt><dd>SQL</dd></div>
+        </dl>
+        <h3 style="margin:1.5rem 0 0.5rem;font-size:1.05rem">기능</h3>
+        <ul class="feat-list">
+          <li>메타데이터 관리</li>
+          <li>검색·필터</li>
+          <li>카테고리·태깅</li>
+          <li>타임라인 뷰</li>
+        </ul>
+      </article>
+    </div>
+    <div class="mock-card" style="margin-top:1.5rem;text-align:center;background:#f8fafc;border:1px dashed #cbd5e1">
+      <p style="margin:0;color:#64748b;font-size:0.9rem">LAB 1·3~6 — Coming Soon 카드로 통일 가능합니다.</p>
+    </div>
+  </main>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/ui-mockup-main-v3.html">메인 v3</a> · <a href="/lab/2">실제 LAB 2</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-login.html
+++ b/public/ui-mockup-login.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>로그인 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .v3-auth-card h1 { margin: 0 0 0.35rem; font-size: 1.35rem; text-align: center; }
+    .v3-auth-card .sub { text-align: center; font-size: 0.85rem; color: #64748b; margin: 0 0 1.25rem; line-height: 1.5; }
+    .field { margin-bottom: 1rem; }
+    .hint { font-size: 0.75rem; color: #94a3b8; margin-top: 1rem; text-align: center; line-height: 1.5; }
+    .row-between { display: flex; justify-content: center; gap: 0.5rem; margin-top: 1rem; font-size: 0.85rem; }
+    .row-between a { color: #047857; font-weight: 600; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Login</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-login.html">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-auth-shell">
+    <div class="v3-auth-card" id="main">
+      <h1>로그인</h1>
+      <p class="sub">운영·일반 계정 모두 이 화면에서 처리합니다. 운영은 로그인 후 <code>/admin</code> 으로 이동합니다.</p>
+      <div style="margin-bottom:1rem;padding:0.75rem 1rem;font-size:0.85rem;color:#334155;background:#f8fafc;border-radius:0.5rem;border:1px solid #e2e8f0">
+        <strong>운영</strong> → <a href="/login?next=/admin" style="color:#047857">?next=/admin</a>
+      </div>
+      <form action="#" method="get">
+        <div class="field">
+          <label class="mock-label" for="id">아이디</label>
+          <input class="mock-input" id="id" type="text" autocomplete="username" required />
+        </div>
+        <div class="field">
+          <label class="mock-label" for="pw">비밀번호</label>
+          <input class="mock-input" id="pw" type="password" autocomplete="current-password" required />
+        </div>
+        <button type="submit" class="mock-btn mock-btn--primary" style="width:100%;margin-top:0.25rem">로그인</button>
+      </form>
+      <p class="hint">시안: 실제 제출은 React 앱과 연동됩니다.</p>
+      <div class="row-between">
+        <a href="/ui-mockup-signup.html">회원가입</a>
+        <span style="color:#e2e8f0">|</span>
+        <a href="/ui-mockup-main-v3.html">메인 시안</a>
+      </div>
+    </div>
+  </div>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/login">실제 로그인</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-main-v2-layout.html
+++ b/public/ui-mockup-main-v2-layout.html
@@ -1,0 +1,284 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Yeobaek 메인 시안 v2 — 레이아웃 (SINSIWAY형)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    /* ----- Page shell ----- */
+    .v2 { background: #fafafa; color: var(--slate-900); }
+    .v2-section { max-width: 72rem; margin: 0 auto; padding: clamp(2.5rem, 5vw, 4rem) 1.25rem; }
+    .v2-eyebrow {
+      font-size: 0.75rem; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase;
+      color: var(--emerald-700); margin: 0 0 0.75rem;
+    }
+    .v2-h2 { font-size: clamp(1.75rem, 4vw, 2.35rem); font-weight: 800; margin: 0 0 0.5rem; letter-spacing: -0.03em; }
+    .v2-lead { color: var(--slate-600); font-size: clamp(1rem, 2vw, 1.1rem); line-height: 1.65; margin: 0; max-width: 36rem; }
+
+    /* ----- Hero: 2-column (layout ref) ----- */
+    .v2-hero {
+      padding-top: 2rem;
+      padding-bottom: clamp(2rem, 5vw, 3.5rem);
+      background: linear-gradient(180deg, #fff 0%, #f4fbf7 100%);
+      border-bottom: 1px solid var(--slate-200);
+    }
+    .v2-hero-grid {
+      max-width: 72rem; margin: 0 auto; padding: 0 1.25rem;
+      display: grid; gap: 2rem; align-items: center;
+    }
+    @media (min-width: 900px) {
+      .v2-hero-grid { grid-template-columns: 1fr 1.05fr; gap: 3rem; min-height: min(70vh, 36rem); }
+    }
+    .v2-hero-kicker { font-size: clamp(1.85rem, 4.5vw, 2.75rem); font-weight: 800; line-height: 1.2; margin: 0 0 1rem; letter-spacing: -0.03em; }
+    .v2-hero-sub { color: var(--emerald-800); font-weight: 700; font-size: clamp(1rem, 2vw, 1.15rem); margin: 0 0 1rem; }
+    .v2-hero-p { color: var(--slate-600); line-height: 1.7; margin: 0 0 1.5rem; max-width: 32rem; }
+    .v2-hero-cta { display: flex; flex-wrap: wrap; gap: 0.65rem; }
+    .v2-hero-visual {
+      position: relative; border-radius: 1.25rem; overflow: hidden;
+      box-shadow: 0 20px 50px rgba(6, 95, 70, 0.18);
+      aspect-ratio: 4/3; background: var(--emerald-900);
+    }
+    .v2-hero-visual img { width: 100%; height: 100%; object-fit: cover; display: block; }
+    .v2-scroll-hint {
+      display: none;
+    }
+    @media (min-width: 900px) {
+      .v2-scroll-hint {
+        display: flex; align-items: center; gap: 0.35rem; margin-top: 2rem;
+        font-size: 0.7rem; font-weight: 600; letter-spacing: 0.15em; color: var(--slate-400); text-transform: uppercase;
+      }
+    }
+
+    /* ----- Service cards: horizontal row ----- */
+    .v2-services { background: #fff; }
+    .v2-cards {
+      display: grid; gap: 1.25rem;
+      grid-template-columns: 1fr;
+    }
+    @media (min-width: 720px) {
+      .v2-cards { grid-template-columns: repeat(3, 1fr); }
+    }
+    .v2-card {
+      background: #fff; border: 1px solid var(--slate-200); border-radius: 1rem;
+      padding: 1.35rem 1.25rem; box-shadow: 0 4px 20px rgba(15, 23, 42, 0.04);
+      display: flex; flex-direction: column; min-height: 17rem;
+      transition: border-color 0.15s, box-shadow 0.15s;
+    }
+    .v2-card:hover { border-color: var(--emerald-300); box-shadow: 0 8px 28px rgba(6, 95, 70, 0.1); }
+    .v2-card-icon {
+      width: 3rem; height: 3rem; border-radius: 0.75rem; margin-bottom: 1rem;
+      background: linear-gradient(135deg, var(--emerald-100), #d1fae5);
+      display: flex; align-items: center; justify-content: center;
+    }
+    .v2-card-icon img { width: 1.75rem; height: 1.75rem; object-fit: contain; }
+    .v2-card h3 { margin: 0 0 0.65rem; font-size: 1.1rem; font-weight: 800; letter-spacing: -0.02em; }
+    .v2-card ul { margin: 0; padding-left: 1.1rem; color: var(--slate-600); font-size: 0.88rem; line-height: 1.55; flex: 1; }
+    .v2-card a {
+      margin-top: 1rem; font-size: 0.88rem; font-weight: 700; color: var(--emerald-700); text-decoration: none;
+      display: inline-flex; align-items: center; gap: 0.25rem;
+    }
+    .v2-card a:hover { gap: 0.45rem; }
+
+    /* ----- News: split ----- */
+    .v2-news { background: #f8fafc; border-top: 1px solid var(--slate-200); }
+    .v2-news-grid {
+      display: grid; gap: 2rem;
+    }
+    @media (min-width: 768px) {
+      .v2-news-grid { grid-template-columns: minmax(12rem, 16rem) 1fr; gap: 3rem; align-items: start; }
+    }
+    .v2-news-aside .v2-lead { max-width: none; }
+    .v2-news-list { list-style: none; margin: 0; padding: 0; border-top: 1px solid var(--slate-200); }
+    .v2-news-list li {
+      display: grid; grid-template-columns: auto 1fr; gap: 1rem; align-items: baseline;
+      padding: 1.1rem 0; border-bottom: 1px solid var(--slate-200);
+    }
+    .v2-news-date { font-weight: 800; color: var(--emerald-800); font-size: 0.95rem; white-space: nowrap; }
+    .v2-news-list a { color: var(--slate-900); text-decoration: none; font-weight: 600; font-size: 0.95rem; line-height: 1.45; }
+    .v2-news-list a:hover { color: var(--emerald-700); text-decoration: underline; }
+
+    /* ----- Inquiry band ----- */
+    .v2-inquiry {
+      position: relative; overflow: hidden;
+      background: linear-gradient(115deg, #0d9488 0%, #047857 45%, #065f46 100%);
+      color: #fff; padding: clamp(2.5rem, 6vw, 4rem) 1.25rem;
+    }
+    .v2-inquiry::after {
+      content: ""; position: absolute; right: -15%; top: -40%; width: 50%; height: 140%;
+      background: radial-gradient(circle, rgba(255,255,255,0.12) 0%, transparent 65%); pointer-events: none;
+    }
+    .v2-inquiry-grid {
+      max-width: 72rem; margin: 0 auto; position: relative; z-index: 1;
+      display: grid; gap: 2rem;
+    }
+    @media (min-width: 800px) {
+      .v2-inquiry-grid { grid-template-columns: 1fr 1fr; gap: 3rem; align-items: start; }
+    }
+    .v2-inquiry h2 { margin: 0 0 0.75rem; font-size: clamp(1.5rem, 3vw, 2rem); font-weight: 800; line-height: 1.3; }
+    .v2-inquiry p { margin: 0; opacity: 0.92; font-size: 0.95rem; line-height: 1.65; max-width: 28rem; }
+    .v2-form { display: flex; flex-direction: column; gap: 0.75rem; }
+    .v2-form label { font-size: 0.72rem; font-weight: 700; letter-spacing: 0.04em; opacity: 0.9; }
+    .v2-form input, .v2-form textarea {
+      width: 100%; padding: 0.65rem 0.85rem; border-radius: 0.5rem; border: 1px solid rgba(255,255,255,0.45);
+      background: rgba(255,255,255,0.1); color: #fff; font-family: inherit; font-size: 0.9rem;
+    }
+    .v2-form input::placeholder, .v2-form textarea::placeholder { color: rgba(255,255,255,0.55); }
+    .v2-form input:focus, .v2-form textarea:focus {
+      outline: 2px solid rgba(255,255,255,0.6); outline-offset: 1px; border-color: rgba(255,255,255,0.7);
+    }
+    .v2-form textarea { min-height: 5.5rem; resize: vertical; }
+    .v2-form button {
+      align-self: flex-start; margin-top: 0.35rem;
+      padding: 0.65rem 1.35rem; border-radius: 999px; border: none; cursor: pointer;
+      background: #fff; color: var(--emerald-900); font-weight: 800; font-size: 0.9rem; font-family: inherit;
+    }
+    .v2-form button:hover { filter: brightness(1.05); }
+
+  </style>
+</head>
+<body class="v2 v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Layout</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-main-v2-layout.html#main">홈</a>
+        <a class="v3-pill" href="#services">서비스</a>
+        <a class="v3-pill" href="/about">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="v2-hero" aria-labelledby="v2-hero-title">
+      <div class="v2-hero-grid">
+        <div>
+          <p class="v2-eyebrow">University LIS Club</p>
+          <h1 id="v2-hero-title" class="v2-hero-kicker">문헌정보학을 바탕으로<br />만드는 디지털 경험</h1>
+          <p class="v2-hero-sub">Yeobaek Web</p>
+          <p class="v2-hero-p">
+            챗봇·아카이빙·전시·LAB을 한 흐름으로 연결합니다. 아래 서비스 카드에서 각 영역으로 이동할 수 있습니다.
+          </p>
+          <div class="v2-hero-cta">
+            <a class="mock-btn mock-btn--primary" href="#services">서비스 보기</a>
+            <a class="mock-btn mock-btn--ghost" href="/recruit">모집 안내</a>
+          </div>
+          <div class="v2-scroll-hint" aria-hidden="true">
+            <span>SCROLL</span>
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12l7 7 7-7"/></svg>
+          </div>
+        </div>
+        <div class="v2-hero-visual">
+          <img src="/backend/image/gomdol.jpg" alt="" width="800" height="600" />
+        </div>
+      </div>
+    </section>
+
+    <section class="v2-services v2-section" id="services" aria-labelledby="v2-svc-title">
+      <p class="v2-eyebrow">Services</p>
+      <h2 id="v2-svc-title" class="v2-h2">여백이 제공하는 기능</h2>
+      <p class="v2-lead" style="margin-bottom: 2rem">가로 3열 동일 높이 카드 — 레퍼런스의 제품 카드 행과 동일한 정보 구조입니다.</p>
+      <div class="v2-cards">
+        <article class="v2-card">
+          <div class="v2-card-icon"><img src="/backend/image/mascot_chatbot.png" alt="" /></div>
+          <h3>챗봇 · 여불이</h3>
+          <ul>
+            <li>LIS 맥락 질의응답</li>
+            <li>문서 기반 RAG</li>
+            <li>빠른 질문 템플릿</li>
+          </ul>
+          <a href="/chatbot">둘러보기 →</a>
+        </article>
+        <article class="v2-card">
+          <div class="v2-card-icon"><img src="/backend/image/Archive.png" alt="" /></div>
+          <h3>디지털 아카이빙</h3>
+          <ul>
+            <li>산출물·문서 보존</li>
+            <li>메타데이터·검색</li>
+            <li>동아리 간 공유</li>
+          </ul>
+          <a href="/archiving">둘러보기 →</a>
+        </article>
+        <article class="v2-card">
+          <div class="v2-card-icon"><img src="/backend/image/digicu.png" alt="" /></div>
+          <h3>산출물 전시</h3>
+          <ul>
+            <li>LAB 카탈로그</li>
+            <li>전시형 탐색</li>
+            <li>추후 큐레이션</li>
+          </ul>
+          <a href="/exhibition">둘러보기 →</a>
+        </article>
+      </div>
+    </section>
+
+    <section class="v2-news v2-section" id="news" aria-labelledby="v2-news-title">
+      <div class="v2-news-grid">
+        <aside class="v2-news-aside">
+          <p class="v2-eyebrow">News</p>
+          <h2 id="v2-news-title" class="v2-h2">소식</h2>
+          <p class="v2-lead" style="margin-top: 0.75rem">왼쪽 고정 폭 제목 블록 + 오른쪽 리스트 레이아웃입니다.</p>
+        </aside>
+        <div>
+          <ul class="v2-news-list">
+            <li>
+              <span class="v2-news-date">2026.05</span>
+              <a href="#">메인 페이지 UI 시안 v2 (레이아웃 분기) 반영</a>
+            </li>
+            <li>
+              <span class="v2-news-date">2026.04</span>
+              <a href="#">모집 섹션 및 통합 로그인 흐름 정리</a>
+            </li>
+            <li>
+              <span class="v2-news-date">2026.03</span>
+              <a href="#">챗봇 RAG 백엔드 연동 및 Mongo 벡터 검색</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="v2-inquiry" id="inquiry" aria-labelledby="v2-inq-title">
+      <div class="v2-inquiry-grid">
+        <div>
+          <h2 id="v2-inq-title">문의하기</h2>
+          <p>하단 그라데이션 밴드에 짧은 폼을 두는 패턴입니다. 실제 구현 시에는 백엔드·폼 스팸 방지 등을 연결하면 됩니다.</p>
+        </div>
+        <form class="v2-form" action="#" method="get" onsubmit="return false;">
+          <div>
+            <label for="q-name">이름</label>
+            <input id="q-name" type="text" name="name" placeholder="이름" autocomplete="name" />
+          </div>
+          <div>
+            <label for="q-email">이메일</label>
+            <input id="q-email" type="email" name="email" placeholder="email@example.com" autocomplete="email" />
+          </div>
+          <div>
+            <label for="q-msg">내용</label>
+            <textarea id="q-msg" name="message" placeholder="문의 내용을 입력해 주세요"></textarea>
+          </div>
+          <button type="submit">보내기</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="mock-footer">
+    메인 시안 v2 (SINSIWAY형 레이아웃) ·
+    <a href="/ui-mockup-index.html">시안 목록</a> ·
+    <a href="/ui-mockup-main-v3.html">메인 v3</a> ·
+    <a href="/ui-mockup-yeobaek.html">v1</a> ·
+    <a href="/">실제 앱</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-main-v3.html
+++ b/public/ui-mockup-main-v3.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Yeobaek 메인 시안 v3 — 헤더(Recruit형) + 히어로(v1) + 본문(v2)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet" />
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" width="32" height="32" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Web</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-index.html">시안 목록</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill" href="#services">서비스</a>
+        <a class="v3-pill" href="/about">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/login">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="v3-hero" aria-labelledby="v3-hero-title">
+      <div class="v3-hero-bg" role="presentation"></div>
+      <div class="v3-hero-overlay" aria-hidden="true"></div>
+      <div class="v3-hero-content">
+        <p class="v3-hero-kicker">문헌정보학 · 데이터 · AI</p>
+        <h1 id="v3-hero-title">Yeobaek Web</h1>
+        <p class="v3-hero-lead">
+          학과 소통과 전공 동아리 활성화를 위한 웹 공간입니다.<br />
+          챗봇 · 아카이빙 · 전시 · LAB을 한곳에서 탐색해 보세요.
+        </p>
+        <div class="v3-hero-cta">
+          <button type="button" class="btn-a btn-solid" onclick="document.getElementById('services')?.scrollIntoView({ behavior: 'smooth' })">
+            Service 구경하기
+          </button>
+          <button type="button" class="btn-a btn-outline" onclick="document.getElementById('news')?.scrollIntoView({ behavior: 'smooth' })">
+            소식 보기
+          </button>
+        </div>
+      </div>
+      <div class="v3-scroll" aria-hidden="true">
+        <span>SCROLL</span>
+        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12l7 7 7-7" /></svg>
+      </div>
+    </section>
+
+    <section class="v3-band-white v3-section" id="stats" aria-label="핵심 수치">
+      <p class="v3-eyebrow">Numbers</p>
+      <h2 class="v3-h2">여백 한눈에 보기</h2>
+      <p class="v3-lead" style="margin-bottom: 2rem">동아리 핵심 수치를 한눈에 확인하세요.</p>
+      <div class="v3-stat-grid">
+        <div class="v3-stat-card">
+          <p class="v3-stat-num">6</p>
+          <p class="v3-stat-label">LAB</p>
+        </div>
+        <div class="v3-stat-card">
+          <p class="v3-stat-num">30<span class="v3-stat-suffix">+</span></p>
+          <p class="v3-stat-label">부원</p>
+        </div>
+        <div class="v3-stat-card">
+          <p class="v3-stat-num">10<span class="v3-stat-suffix">+</span></p>
+          <p class="v3-stat-label">프로젝트</p>
+        </div>
+        <div class="v3-stat-card">
+          <p class="v3-stat-num">3<span class="v3-stat-suffix">년</span></p>
+          <p class="v3-stat-label">운영</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="v3-band-white v3-section" id="services" aria-labelledby="v3-svc-title" style="border-top: 1px solid #e2e8f0">
+      <p class="v3-eyebrow">Services</p>
+      <h2 id="v3-svc-title" class="v3-h2">서비스</h2>
+      <p class="v3-lead" style="margin-bottom: 2rem">가로 3열 카드 · 상단 이미지 + 본문 구조입니다.</p>
+      <div class="v3-cards">
+        <article class="v3-card">
+          <div class="v3-card-media">
+            <img src="/backend/image/chatbot_image.jpg" alt="" />
+          </div>
+          <div class="v3-card-body">
+            <div class="v3-card-icon"><img src="/backend/image/mascot_chatbot.png" alt="" /></div>
+            <h3>챗봇 · 여불이</h3>
+            <ul>
+              <li>LIS 맥락 질의응답</li>
+              <li>문서 기반 RAG</li>
+              <li>빠른 질문 템플릿</li>
+            </ul>
+            <a href="/chatbot">둘러보기 →</a>
+          </div>
+        </article>
+        <article class="v3-card">
+          <div class="v3-card-media">
+            <img src="/backend/image/digitalA.png" alt="" />
+          </div>
+          <div class="v3-card-body">
+            <div class="v3-card-icon"><img src="/backend/image/Archive.png" alt="" /></div>
+            <h3>디지털 아카이빙</h3>
+            <ul>
+              <li>산출물·문서 보존</li>
+              <li>메타데이터·검색</li>
+              <li>동아리 간 공유</li>
+            </ul>
+            <a href="/archiving">둘러보기 →</a>
+          </div>
+        </article>
+        <article class="v3-card">
+          <div class="v3-card-media">
+            <img src="/backend/image/digicu.png" alt="" />
+          </div>
+          <div class="v3-card-body">
+            <div class="v3-card-icon"><img src="/backend/image/digicu.png" alt="" /></div>
+            <h3>산출물 전시</h3>
+            <ul>
+              <li>LAB 카탈로그</li>
+              <li>전시형 탐색</li>
+              <li>추후 큐레이션</li>
+            </ul>
+            <a href="/exhibition">둘러보기 →</a>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="v3-band-slate v3-section" id="news" aria-labelledby="v3-news-title">
+      <div class="v3-news-grid">
+        <aside>
+          <p class="v3-eyebrow">News</p>
+          <h2 id="v3-news-title" class="v3-h2">소식</h2>
+          <p class="v3-lead" style="margin-top: 0.75rem">좌측 제목 블록 + 우측 리스트.</p>
+        </aside>
+        <div>
+          <ul class="v3-news-list">
+            <li>
+              <span class="v3-news-date">2026.05</span>
+              <a href="#">메인 v3 시안: Recruit형 헤더 + 히어로 + 통계 + 서비스 카드</a>
+            </li>
+            <li>
+              <span class="v3-news-date">2026.05</span>
+              <a href="#">메인 v2 시안: SINSIWAY형 레이아웃 분기</a>
+            </li>
+            <li>
+              <span class="v3-news-date">2026.04</span>
+              <a href="#">통합 로그인 및 모집 Phase 연동</a>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="v3-inquiry" id="inquiry" aria-labelledby="v3-inq-title">
+      <div class="v3-inquiry-grid">
+        <div>
+          <h2 id="v3-inq-title">문의하기</h2>
+          <p>그라데이션 + 2단 폼 밴드입니다.</p>
+        </div>
+        <form class="v3-form" action="#" method="get" onsubmit="return false;">
+          <div>
+            <label for="q-name">이름</label>
+            <input id="q-name" type="text" placeholder="이름" autocomplete="name" />
+          </div>
+          <div>
+            <label for="q-email">이메일</label>
+            <input id="q-email" type="email" placeholder="email@example.com" autocomplete="email" />
+          </div>
+          <div>
+            <label for="q-msg">내용</label>
+            <textarea id="q-msg" placeholder="문의 내용"></textarea>
+          </div>
+          <button type="submit">보내기</button>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="mock-footer">
+    메인 시안 v3 ·
+    <a href="/ui-mockup-index.html">시안 목록</a> ·
+    <a href="/mockup-shell-v3.css">v3 셸 CSS</a> ·
+    <a href="/ui-mockup-main-v2-layout.html">v2</a> ·
+    <a href="/ui-mockup-yeobaek.html">v1</a> ·
+    <a href="/">실제 앱</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-me.html
+++ b/public/ui-mockup-me.html
@@ -1,0 +1,78 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>내 계정 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .me-bar { background: #fff; border-bottom: 1px solid #e2e8f0; padding: 1.25rem 1.25rem; }
+    .me-bar-inner { max-width: 64rem; margin: 0 auto; display: flex; flex-wrap: wrap; align-items: center; gap: 1rem; justify-content: space-between; }
+    .avatar { width: 3.5rem; height: 3.5rem; border-radius: 999px; background: #d1fae5; display: flex; align-items: center; justify-content: center; font-weight: 800; color: #065f46; }
+    .me-actions { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+    .me-two { display: grid; gap: 1.25rem; margin-top: 1.25rem; grid-template-columns: 1fr; }
+    @media (min-width: 640px) {
+      .me-two { grid-template-columns: 1fr 1fr; }
+    }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Me</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill v3-pill--active" href="/ui-mockup-login.html">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="me-bar">
+    <div class="me-bar-inner">
+      <div style="display:flex;align-items:center;gap:1rem">
+        <div class="avatar" aria-hidden="true">U</div>
+        <div>
+          <h1 class="v3-h1" style="font-size:1.25rem">내 계정</h1>
+          <p style="margin:0.2rem 0 0;color:#64748b;font-size:0.85rem">일반 사용자 세션 (시안)</p>
+        </div>
+      </div>
+      <div class="me-actions">
+        <a class="mock-btn mock-btn--ghost" href="/ui-mockup-main-v3.html">메인 시안</a>
+        <button type="button" class="mock-btn" style="background:#0f172a;color:#fff;border:none">로그아웃</button>
+      </div>
+    </div>
+  </div>
+
+  <main id="main" class="v3-section v3-band-slate">
+    <div class="mock-card" style="background:#fff;border:1px solid #e2e8f0;border-radius:1rem;padding:1.25rem;box-shadow:0 4px 20px rgba(15,23,42,0.04)">
+      <h2 style="margin:0 0 0.5rem;font-size:1.05rem">알림</h2>
+      <p style="margin:0;color:#64748b;line-height:1.65;font-size:0.95rem">프로필·알림 설정은 추후 이 영역에 배치할 수 있습니다.</p>
+    </div>
+    <div class="me-two">
+      <div class="mock-card" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:1rem;padding:1.25rem">
+        <h3 style="margin:0 0 0.35rem;font-size:1rem">최근 활동</h3>
+        <p style="margin:0;font-size:0.85rem;color:#64748b">표시할 항목이 없습니다.</p>
+      </div>
+      <div class="mock-card" style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:1rem;padding:1.25rem">
+        <h3 style="margin:0 0 0.35rem;font-size:1rem">바로가기</h3>
+        <p style="margin:0;font-size:0.85rem;color:#64748b">모집 · 챗봇 링크를 모을 수 있습니다.</p>
+      </div>
+    </div>
+  </main>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/me">실제 /me</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-signup.html
+++ b/public/ui-mockup-signup.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>회원가입 — Yeobaek UI 시안 (v3 셸)</title>
+  <link rel="stylesheet" href="/mockup-shared.css" />
+  <link rel="stylesheet" href="/mockup-shell-v3.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;600;700&display=swap" rel="stylesheet" />
+  <style>
+    .v3-auth-card h1 { margin: 0 0 0.25rem; font-size: 1.35rem; text-align: center; }
+    .sub { text-align: center; font-size: 0.85rem; color: #64748b; margin: 0 0 1.25rem; }
+    .field { margin-bottom: 0.85rem; }
+    .chk { display: flex; align-items: flex-start; gap: 0.5rem; font-size: 0.85rem; color: #475569; margin: 1rem 0; }
+    .chk input { margin-top: 0.2rem; }
+  </style>
+</head>
+<body class="v3-shell">
+  <a class="skip" href="#main">본문으로</a>
+  <a class="v3-float" href="/ui-mockup-main-v3.html#inquiry">문의</a>
+
+  <header class="v3-head">
+    <div class="v3-head-inner">
+      <a class="v3-brand" href="/">
+        <img src="/backend/image/logo.png" alt="" />
+        <span class="v3-brand-title">YEOBAEK<span class="v3-brand-pipe">| Signup</span></span>
+      </a>
+      <nav class="v3-head-nav" aria-label="주요 메뉴">
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#main">홈</a>
+        <a class="v3-pill" href="/ui-mockup-main-v3.html#services">서비스</a>
+        <a class="v3-pill" href="/ui-mockup-about.html">소개</a>
+        <a class="v3-pill" href="/recruit">모집</a>
+        <a class="v3-pill" href="/ui-mockup-login.html">로그인</a>
+      </nav>
+    </div>
+  </header>
+
+  <div class="v3-auth-shell">
+    <div class="v3-auth-card" id="main">
+      <h1>회원가입</h1>
+      <p class="sub">로그인 시안과 동일한 카드 폭·여백입니다.</p>
+      <form action="#" method="get">
+        <div class="field">
+          <label class="mock-label" for="email">이메일</label>
+          <input class="mock-input" id="email" type="email" autocomplete="email" required />
+        </div>
+        <div class="field">
+          <label class="mock-label" for="id">아이디</label>
+          <input class="mock-input" id="id" type="text" autocomplete="username" required />
+        </div>
+        <div class="field">
+          <label class="mock-label" for="id2">아이디 확인</label>
+          <input class="mock-input" id="id2" type="text" required />
+        </div>
+        <div class="field">
+          <label class="mock-label" for="pw">비밀번호</label>
+          <input class="mock-input" id="pw" type="password" autocomplete="new-password" required />
+        </div>
+        <div class="field">
+          <label class="mock-label" for="pw2">비밀번호 확인</label>
+          <input class="mock-input" id="pw2" type="password" autocomplete="new-password" required />
+        </div>
+        <label class="chk">
+          <input type="checkbox" required />
+          <span>개인정보 수집·이용에 동의합니다.</span>
+        </label>
+        <button type="submit" class="mock-btn mock-btn--primary" style="width:100%">가입하기</button>
+      </form>
+      <p style="text-align:center;margin:1rem 0 0;font-size:0.85rem">
+        이미 계정이 있나요? <a href="/ui-mockup-login.html" style="color:#047857;font-weight:700">로그인</a>
+      </p>
+    </div>
+  </div>
+
+  <footer class="mock-footer">
+    시안 v3 셸 · <a href="/ui-mockup-index.html">목록</a> · <a href="/signup">실제 회원가입</a>
+  </footer>
+</body>
+</html>

--- a/public/ui-mockup-yeobaek.html
+++ b/public/ui-mockup-yeobaek.html
@@ -1,0 +1,652 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Yeobaek — UI 시안 (메인·공통)</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=Noto+Sans+KR:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --emerald-950: #022c22;
+      --emerald-900: #064e3b;
+      --emerald-800: #065f46;
+      --emerald-700: #047857;
+      --emerald-600: #059669;
+      --emerald-100: #d1fae5;
+      --emerald-50: #ecfdf5;
+      --slate-900: #0f172a;
+      --slate-700: #334155;
+      --slate-600: #475569;
+      --slate-200: #e2e8f0;
+      --white: #fff;
+      --radius-lg: 1rem;
+      --radius-xl: 1.25rem;
+      --shadow: 0 12px 40px rgba(6, 78, 59, 0.12);
+      --font-sans: "Noto Sans KR", "DM Sans", system-ui, sans-serif;
+      --step--1: clamp(0.875rem, 0.82rem + 0.2vw, 0.95rem);
+      --step-0: clamp(1rem, 0.92rem + 0.35vw, 1.125rem);
+      --step-1: clamp(1.15rem, 1rem + 0.5vw, 1.35rem);
+      --step-2: clamp(1.5rem, 1.2rem + 1vw, 2rem);
+      --step-3: clamp(2rem, 1.5rem + 1.8vw, 2.75rem);
+      --step-4: clamp(2.5rem, 1.8rem + 2.8vw, 3.5rem);
+      --max: 72rem;
+    }
+
+    *, *::before, *::after { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      font-family: var(--font-sans);
+      font-size: var(--step-0);
+      color: var(--slate-900);
+      background: #f8fafc;
+      line-height: 1.6;
+    }
+
+    .skip {
+      position: absolute;
+      left: -9999px;
+      top: auto;
+      width: 1px;
+      height: 1px;
+      overflow: hidden;
+    }
+    .skip:focus {
+      left: 1rem;
+      top: 1rem;
+      width: auto;
+      height: auto;
+      padding: 0.5rem 1rem;
+      background: var(--emerald-900);
+      color: var(--white);
+      border-radius: var(--radius-lg);
+      z-index: 9999;
+    }
+
+    /* ----- Header ----- */
+    .site-header {
+      position: fixed;
+      inset: 0 0 auto 0;
+      z-index: 100;
+      background: rgba(6, 95, 70, 0.88);
+      backdrop-filter: blur(12px);
+      border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+    }
+    .site-header__inner {
+      max-width: var(--max);
+      margin: 0 auto;
+      padding: 0.75rem 1.25rem;
+      display: flex;
+      align-items: center;
+      gap: 1rem;
+    }
+    .brand {
+      display: flex;
+      align-items: center;
+      gap: 0.6rem;
+      text-decoration: none;
+      color: var(--white);
+      font-weight: 700;
+      font-size: var(--step-1);
+      white-space: nowrap;
+    }
+    .brand img { height: 1.75rem; width: auto; }
+
+    .nav-main {
+      flex: 1;
+      display: flex;
+      justify-content: center;
+      flex-wrap: wrap;
+      gap: 0.25rem 1.25rem;
+    }
+    .nav-main a {
+      color: rgba(255, 255, 255, 0.92);
+      text-decoration: none;
+      font-weight: 500;
+      font-size: var(--step--1);
+      padding: 0.35rem 0.2rem;
+      border-radius: 0.35rem;
+      transition: color 0.15s, background 0.15s;
+    }
+    .nav-main a:hover,
+    .nav-main a:focus-visible {
+      color: var(--white);
+      background: rgba(255, 255, 255, 0.1);
+      outline: none;
+    }
+
+    .header-actions {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .btn-ghost {
+      border: 1px solid rgba(255, 255, 255, 0.35);
+      background: transparent;
+      color: var(--white);
+      padding: 0.45rem 0.85rem;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: var(--step--1);
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .btn-ghost:hover,
+    .btn-ghost:focus-visible {
+      background: rgba(255, 255, 255, 0.12);
+      border-color: rgba(255, 255, 255, 0.55);
+      outline: 2px solid var(--emerald-100);
+      outline-offset: 2px;
+    }
+    .btn-primary {
+      background: var(--white);
+      color: var(--emerald-900);
+      border: none;
+      padding: 0.45rem 1rem;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: var(--step--1);
+      font-weight: 600;
+      cursor: pointer;
+      text-decoration: none;
+      display: inline-flex;
+      align-items: center;
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+    .btn-primary:hover,
+    .btn-primary:focus-visible {
+      transform: translateY(-1px);
+      box-shadow: 0 4px 14px rgba(0, 0, 0, 0.15);
+      outline: 2px solid var(--emerald-100);
+      outline-offset: 2px;
+    }
+
+    @media (max-width: 768px) {
+      .nav-main { order: 3; width: 100%; justify-content: flex-start; padding-top: 0.25rem; border-top: 1px solid rgba(255,255,255,0.15); }
+      .site-header__inner { flex-wrap: wrap; }
+    }
+
+    /* ----- Hero ----- */
+    .hero {
+      min-height: 100vh;
+      min-height: 100dvh;
+      position: relative;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      align-items: center;
+      text-align: center;
+      padding: 6rem 1.25rem 4rem;
+    }
+    .hero__bg {
+      position: absolute;
+      inset: 0;
+      background: var(--emerald-900) center / cover no-repeat;
+      background-image: linear-gradient(135deg, rgba(6, 78, 59, 0.55), rgba(15, 23, 42, 0.45)), url("/backend/image/gomdol.jpg");
+      filter: brightness(0.92);
+    }
+    .hero__content {
+      position: relative;
+      z-index: 2;
+      max-width: 42rem;
+    }
+    .hero__eyebrow {
+      display: inline-block;
+      font-size: var(--step--1);
+      font-weight: 600;
+      color: rgba(255, 255, 255, 0.95);
+      letter-spacing: 0.04em;
+      margin-bottom: 0.75rem;
+      text-shadow: 0 1px 2px rgba(0, 0, 0, 0.25);
+    }
+    .hero__title {
+      margin: 0 0 1rem;
+      font-size: var(--step-4);
+      font-weight: 700;
+      color: var(--white);
+      line-height: 1.15;
+      letter-spacing: -0.02em;
+      text-shadow: 0 2px 24px rgba(0, 0, 0, 0.35);
+    }
+    .hero__lead {
+      margin: 0 0 2rem;
+      font-size: var(--step-1);
+      color: rgba(255, 255, 255, 0.92);
+      max-width: 36rem;
+      margin-left: auto;
+      margin-right: auto;
+      text-shadow: 0 1px 8px rgba(0, 0, 0, 0.3);
+    }
+    .hero__cta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.75rem;
+      justify-content: center;
+    }
+    .btn-solid {
+      min-width: 11rem;
+      padding: 0.9rem 1.5rem;
+      border-radius: 999px;
+      font-family: inherit;
+      font-size: var(--step--1);
+      font-weight: 600;
+      border: none;
+      cursor: pointer;
+      transition: transform 0.15s, box-shadow 0.15s;
+    }
+    .btn-solid--light {
+      background: rgba(255, 255, 255, 0.95);
+      color: var(--emerald-950);
+    }
+    .btn-solid--outline {
+      background: rgba(255, 255, 255, 0.12);
+      color: var(--white);
+      border: 1px solid rgba(255, 255, 255, 0.45);
+    }
+    .btn-solid:hover,
+    .btn-solid:focus-visible {
+      transform: scale(1.02);
+      outline: 2px solid var(--emerald-100);
+      outline-offset: 2px;
+    }
+
+    .scroll-hint {
+      position: absolute;
+      bottom: 1.75rem;
+      left: 50%;
+      transform: translateX(-50%);
+      color: rgba(255, 255, 255, 0.85);
+      font-size: 0.8rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      gap: 0.35rem;
+      z-index: 2;
+    }
+    .scroll-hint svg { opacity: 0.9; }
+
+    /* ----- Mission ----- */
+    .section {
+      max-width: var(--max);
+      margin: 0 auto;
+      padding: clamp(3rem, 8vw, 5rem) 1.25rem;
+    }
+    .section--tight { padding-top: clamp(2.5rem, 6vw, 4rem); padding-bottom: clamp(2.5rem, 6vw, 4rem); }
+    .section__title {
+      font-size: var(--step-3);
+      font-weight: 700;
+      color: var(--slate-900);
+      text-align: center;
+      margin: 0 0 1rem;
+      letter-spacing: -0.02em;
+    }
+    .section__lead {
+      text-align: center;
+      color: var(--slate-600);
+      font-size: var(--step-1);
+      max-width: 40rem;
+      margin: 0 auto;
+      line-height: 1.7;
+    }
+
+    /* ----- Services carousel ----- */
+    .services {
+      background: var(--white);
+      border-radius: var(--radius-xl);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+      border: 1px solid var(--slate-200);
+      display: grid;
+      grid-template-columns: 1fr;
+    }
+    @media (min-width: 900px) {
+      .services { grid-template-columns: 1fr 1fr; min-height: 26rem; }
+    }
+    .services__visual {
+      position: relative;
+      background: linear-gradient(160deg, var(--emerald-50), #f0fdf4);
+      min-height: 16rem;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 1.5rem;
+    }
+    .services__visual img {
+      max-width: 100%;
+      max-height: 18rem;
+      object-fit: contain;
+      border-radius: var(--radius-lg);
+      transition: opacity 0.35s ease;
+    }
+    .services__panel {
+      padding: clamp(1.5rem, 4vw, 2.75rem);
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      position: relative;
+    }
+    .services__nav {
+      display: flex;
+      gap: 0.5rem;
+      margin-top: 1.25rem;
+      flex-wrap: wrap;
+      align-items: center;
+    }
+    .services__nav button {
+      width: 2.5rem;
+      height: 2.5rem;
+      border-radius: 999px;
+      border: 1px solid var(--slate-200);
+      background: var(--white);
+      cursor: pointer;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--emerald-800);
+      transition: background 0.15s, border-color 0.15s;
+    }
+    .services__nav button:hover,
+    .services__nav button:focus-visible {
+      background: var(--emerald-50);
+      border-color: var(--emerald-600);
+      outline: none;
+    }
+    .dots {
+      display: flex;
+      gap: 0.4rem;
+      margin-left: auto;
+    }
+    .dots button {
+      width: 0.5rem;
+      height: 0.5rem;
+      padding: 0;
+      border: none;
+      border-radius: 999px;
+      background: #cbd5e1;
+      cursor: pointer;
+      transition: width 0.2s, background 0.2s;
+    }
+    .dots button[aria-current="true"] {
+      background: var(--emerald-700);
+      width: 1.5rem;
+    }
+    .service-title {
+      font-size: var(--step-2);
+      font-weight: 700;
+      margin: 0 0 0.75rem;
+      color: var(--slate-900);
+    }
+    .service-desc {
+      margin: 0 0 1.25rem;
+      color: var(--slate-600);
+      font-size: var(--step-0);
+      line-height: 1.65;
+    }
+    .link-arrow {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+      color: var(--emerald-700);
+      font-weight: 600;
+      text-decoration: none;
+      font-size: var(--step--1);
+    }
+    .link-arrow:hover { gap: 0.55rem; }
+
+    /* ----- Contact ----- */
+    .contact-grid {
+      display: grid;
+      gap: 2rem;
+      align-items: start;
+    }
+    @media (min-width: 768px) {
+      .contact-grid { grid-template-columns: 1fr 1.1fr; }
+    }
+    .map-card {
+      background: var(--white);
+      border-radius: var(--radius-xl);
+      border: 1px solid var(--slate-200);
+      overflow: hidden;
+      box-shadow: var(--shadow);
+    }
+    .map-card img {
+      width: 100%;
+      height: auto;
+      display: block;
+      max-height: 280px;
+      object-fit: cover;
+    }
+    .map-card__footer {
+      padding: 1rem 1.25rem;
+      display: flex;
+      flex-wrap: wrap;
+      gap: 0.5rem;
+      align-items: center;
+      justify-content: space-between;
+      border-top: 1px solid var(--slate-200);
+    }
+    .info-list { list-style: none; padding: 0; margin: 0; }
+    .info-list li {
+      display: flex;
+      gap: 0.75rem;
+      padding: 0.85rem 0;
+      border-bottom: 1px solid var(--slate-200);
+    }
+    .info-list li:last-child { border-bottom: none; }
+    .info-list strong { display: block; font-size: var(--step--1); color: var(--slate-900); }
+    .info-list span { color: var(--slate-600); font-size: var(--step--1); }
+
+    /* ----- Footer ----- */
+    .site-footer {
+      background: var(--slate-900);
+      color: #94a3b8;
+      padding: 2rem 1.25rem;
+      text-align: center;
+      font-size: 0.85rem;
+    }
+    .site-footer a { color: var(--emerald-100); }
+
+    .badge {
+      display: inline-block;
+      font-size: 0.7rem;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      color: var(--emerald-800);
+      background: var(--emerald-100);
+      padding: 0.2rem 0.5rem;
+      border-radius: 0.25rem;
+      margin-bottom: 0.5rem;
+    }
+  </style>
+</head>
+<body>
+  <a class="skip" href="#main">본문으로 건너뛰기</a>
+
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="brand" href="/">
+        <img src="/backend/image/logo.png" alt="" width="28" height="28" />
+        Yeobaek
+      </a>
+      <nav class="nav-main" aria-label="주요 메뉴">
+        <a href="/#hero">홈</a>
+        <a href="/#services">서비스</a>
+        <a href="/about">소개</a>
+        <a href="/recruit">모집</a>
+      </nav>
+      <div class="header-actions">
+        <button type="button" class="btn-ghost" id="btn-audio" aria-pressed="false" title="배경음은 사용자 클릭 후 재생됩니다">
+          배경음 끄기
+        </button>
+        <a class="btn-primary" href="/login">로그인</a>
+      </div>
+    </div>
+  </header>
+
+  <main id="main">
+    <section class="hero" id="hero" aria-labelledby="hero-title">
+      <div class="hero__bg" role="presentation"></div>
+      <div class="hero__content">
+        <span class="hero__eyebrow">문헌정보학 · 데이터 · AI</span>
+        <h1 id="hero-title" class="hero__title">여백과 함께하는<br />디지털 정보 경험</h1>
+        <p class="hero__lead">
+          학과 소통과 전공 동아리 활성화를 위해 만든 웹 공간입니다. 챗봇·아카이빙·전시·LAB을 한곳에서 탐색해 보세요.
+        </p>
+        <div class="hero__cta">
+          <button type="button" class="btn-solid btn-solid--light" data-scroll="#services">서비스 둘러보기</button>
+          <a class="btn-solid btn-solid--outline" href="/about" style="text-decoration: none;">동아리 소개</a>
+        </div>
+      </div>
+      <div class="scroll-hint" aria-hidden="true">
+        <span>아래로 스크롤</span>
+        <svg width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M7 13l5 5 5-5M7 6l5 5 5-5" />
+        </svg>
+      </div>
+    </section>
+
+    <section class="section section--tight" id="mission" style="background: #fff;">
+      <p class="badge">Mission</p>
+      <h2 class="section__title">Yeobaek Web은</h2>
+      <p class="section__lead">
+        문헌정보학을 기반으로 학과의 소통과 정보 공유, 전공 동아리 활성화를 위해 만들어졌습니다. 긴 문장도 모바일에서 자연스럽게 줄바꿈되도록 너비를 제한했습니다.
+      </p>
+    </section>
+
+    <section class="section" id="services" aria-labelledby="services-title">
+      <h2 id="services-title" class="section__title">서비스</h2>
+      <p class="section__lead" style="margin-bottom: 2rem;">카드 안에서 이전·다음을 조작해 모바일에서도 화살표가 잘리지 않게 배치했습니다.</p>
+
+      <div class="services" id="carousel">
+        <div class="services__visual">
+          <img id="svc-img" src="/backend/image/chatbot_image.jpg" alt="" />
+        </div>
+        <div class="services__panel">
+          <h3 class="service-title" id="svc-title">챗봇 · 여불이</h3>
+          <p class="service-desc" id="svc-desc">질문을 입력하면 동아리·전공 맥락을 반영한 답변을 탐색할 수 있습니다.</p>
+          <a class="link-arrow" id="svc-link" href="/chatbot">자세히 보기 →</a>
+          <div class="services__nav">
+            <button type="button" id="svc-prev" aria-label="이전 서비스">‹</button>
+            <button type="button" id="svc-next" aria-label="다음 서비스">›</button>
+            <div class="dots" id="svc-dots" role="tablist" aria-label="서비스 선택"></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section" id="contact" style="background: #f1f5f9;">
+      <h2 class="section__title">연락 · 오시는 길</h2>
+      <p class="section__lead" style="margin-bottom: 2rem;">지도는 썸네일로 두고, 실제 길찾기는 외부 지도 앱 링크로 연결하는 패턴 예시입니다.</p>
+      <div class="contact-grid">
+        <div class="map-card">
+          <img src="/backend/image/map.png" alt="캠퍼스 위치 안내 이미지" />
+          <div class="map-card__footer">
+            <span style="font-size: var(--step--1); color: var(--slate-600);">인천대학교 송도캠퍼스</span>
+            <a class="btn-primary" style="font-size: 0.8rem; padding: 0.4rem 0.9rem;" href="https://map.naver.com" target="_blank" rel="noopener noreferrer">길 찾기</a>
+          </div>
+        </div>
+        <div>
+          <ul class="info-list">
+            <li>
+              <div>
+                <strong>이메일</strong>
+                <span>lisyeobaek@gmail.com</span>
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>인스타그램</strong>
+                <span><a href="https://www.instagram.com/team_yeobeak" target="_blank" rel="noopener noreferrer" style="color: var(--emerald-700);">@team_yeobeak</a></span>
+              </div>
+            </li>
+            <li>
+              <div>
+                <strong>GitHub</strong>
+                <span><a href="https://github.com/YeoGitDa" target="_blank" rel="noopener noreferrer" style="color: var(--emerald-700);">YeoGitDa</a></span>
+              </div>
+            </li>
+          </ul>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>시안 전용 정적 페이지 · 실제 라우팅은 React 앱과 별도입니다.</p>
+    <p style="margin-top: 0.5rem">© Yeobaek — <a href="/">메인 앱으로</a> · <a href="/ui-mockup-index.html">전체 시안 목록</a> · <a href="/ui-mockup-main-v3.html">메인 v3</a></p>
+  </footer>
+
+  <audio id="bg-audio" loop preload="metadata" style="display: none">
+    <source src="/backend/image/musicchristmas.mp3" type="audio/mpeg" />
+  </audio>
+
+  <script>
+    (function () {
+      const slides = [
+        { title: "챗봇 · 여불이", desc: "질문을 입력하면 동아리·전공 맥락을 반영한 답변을 탐색할 수 있습니다.", img: "/backend/image/chatbot_image.jpg", href: "/chatbot" },
+        { title: "디지털 아카이빙", desc: "활동 산출물과 문서를 체계적으로 보관하고 검색할 수 있도록 설계된 영역입니다.", img: "/backend/image/digitalA.png", href: "/archiving" },
+        { title: "동아리 산출물 전시", desc: "추천과 전시를 통해 산출물을 발견하고 연결하는 경험을 목표로 합니다.", img: "/backend/image/digicu.png", href: "/exhibition" },
+      ];
+      let i = 0;
+      const img = document.getElementById("svc-img");
+      const title = document.getElementById("svc-title");
+      const desc = document.getElementById("svc-desc");
+      const link = document.getElementById("svc-link");
+      const dots = document.getElementById("svc-dots");
+
+      function render() {
+        const s = slides[i];
+        img.src = s.img;
+        img.alt = s.title;
+        title.textContent = s.title;
+        desc.textContent = s.desc;
+        link.href = s.href;
+        dots.querySelectorAll("button").forEach((b, j) => b.setAttribute("aria-current", j === i ? "true" : "false"));
+      }
+
+      slides.forEach((_, j) => {
+        const b = document.createElement("button");
+        b.type = "button";
+        b.setAttribute("role", "tab");
+        b.setAttribute("aria-label", "서비스 " + (j + 1));
+        b.addEventListener("click", () => { i = j; render(); });
+        dots.appendChild(b);
+      });
+
+      document.getElementById("svc-prev").addEventListener("click", () => { i = (i - 1 + slides.length) % slides.length; render(); });
+      document.getElementById("svc-next").addEventListener("click", () => { i = (i + 1) % slides.length; render(); });
+      render();
+
+      document.querySelectorAll("[data-scroll]").forEach((el) => {
+        el.addEventListener("click", () => {
+          const sel = el.getAttribute("data-scroll");
+          document.querySelector(sel)?.scrollIntoView({ behavior: "smooth" });
+        });
+      });
+
+      const audio = document.getElementById("bg-audio");
+      const btn = document.getElementById("btn-audio");
+      let playing = false;
+      function sync() {
+        btn.textContent = playing ? "배경음 끄기" : "배경음 켜기";
+        btn.setAttribute("aria-pressed", playing ? "true" : "false");
+      }
+      sync();
+      btn.addEventListener("click", () => {
+        if (playing) {
+          audio.pause();
+          playing = false;
+        } else {
+          audio.play().then(() => { playing = true; sync(); }).catch(() => { playing = false; sync(); });
+          return;
+        }
+        sync();
+      });
+    })();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
# Feat: v3 Recruit형 셸 통일 + 브랜드 서브타이틀 + 시안 허브 연결

## 요약

정적 HTML 시안을 v3 Recruit형 헤더·플로팅 문의 등 공통 맥락으로 맞추고, `npm run dev`로 띄운 React 홈에서도 시안 허브로 갈 수 있게 했습니다.
로고 옆 `YEOBAEK | …` 의 뒷부분은 페이지(또는 라우트)에 따라 달라지도록 정적 시안과 주요 React 화면에 반영했습니다.

## 변경 사항

- `public/mockup-shell-v3.css` — sticky 헤더, pill 내비, 히어로·pagehead·통계·서비스 카드·문의 밴드·auth 셸 등 v3 공통 스타일 분리
- 정적 시안 HTML — `ui-mockup-main-v3` 및 about / chatbot / archiving / exhibition / lab / login / signup / me / main-v2-layout / index 등에서 동일 셸 구조·링크 패턴 정리. 메인 v3 푸터에 시안 목록·셸 CSS 링크 유지
- 시안 목록 접근성
  - React `App.jsx` (홈) 상단에 `시안 목록` → `/ui-mockup-index.html`
  - `ui-mockup-main-v3.html` 헤더에 시안 목록 pill 추가
  - `ui-mockup-index.html` 활성 pill 문구를 시안 목록으로 통일
- 브랜드 서브타이틀
  - 정적 시안: `| Web` 고정 대신 페이지별 `About` / `Chatbot` / `Archiving` / `Exhibition` / `Lab` / `Login` / `Signup` / `Me` / `Layout` 등 (메인 v3는 `Web`, 인덱스는 `Mockups`)
  - React: `SiteBrandMark` 컴포넌트로 홈·상세·로그인·가입 등에서 동일 패턴 적용; LAB 라우트는 `Lab {labNumber}` 형태
- 기타 — `ui-mockup-me.html` 레이아웃/CSS 깨짐 수정, `ui-mockup-yeobaek.html` 푸터에 v3·목록 링크 보강

## 테스트 방법

1. `npm run dev` 후 `/` 에서 우측 상단 `시안 목록` 클릭 → `/ui-mockup-index.html` 로딩 확인
2. `/ui-mockup-main-v3.html` 헤더·푸터에서 시안 목록·각 시안 페이지 이동 확인
3. `/about`, `/archiving`, `/chatbot`, `/exhibition`, `/lab/2` 등에서 로고 옆 `YEOBAEK | …` 문구가 페이지에 맞게 바뀌는지 확인
4. `/login`, `/signup` 에서 밝은 헤더 배경에서도 브랜드 가독성 확인

## 참고 / 비범위

- 모집(`RecruitLayout`)·운영(`AdminShell`) 헤더는 기존 `| Recruit`, `| 운영` 유지
- v1 시안(`ui-mockup-yeobaek.html`)은 히어로 내 전면 내비 구조 유지, 푸터 링크 수준만 조정. 전체 v3 헤더 이식은 별도 논의 가능